### PR TITLE
Update PortHVisitor.py

### DIFF
--- a/Autocoders/Python/src/fprime_ac/generators/visitors/PortHVisitor.py
+++ b/Autocoders/Python/src/fprime_ac/generators/visitors/PortHVisitor.py
@@ -114,18 +114,17 @@ class PortHVisitor(AbstractVisitor.AbstractVisitor):
             #
             # Add modifier here - if any...
             if arg.get_modifier() == "pointer":
-                t = t + " *"
+                t += " *"
             elif arg.get_modifier() == "reference":
-                t = t + " &"
+                t += " &"
             elif arg.get_modifier() == "value":
-                t = t + " "
+                t += " "
             elif TypesList.isPrimitiveType(t) or isEnum:
-                t = t + " "
+                t += " "
             else:
                 t = "const " + t + " &"
 
-            arg_str += "{}{}".format(t, arg.get_name())
-            arg_str += ", "
+            arg_str += f"{t}{arg.get_name()}, "
         arg_str = arg_str.strip(", ")
         return arg_str
 
@@ -164,7 +163,7 @@ class PortHVisitor(AbstractVisitor.AbstractVisitor):
                         % (arg.get_name(), arg.get_type())
                     )
                     sys.exit(-1)
-            elif t in [
+            elif t in (
                 "U8",
                 "U16",
                 "U32",
@@ -183,15 +182,14 @@ class PortHVisitor(AbstractVisitor.AbstractVisitor):
                 "NATIVE_INT_TYPE",
                 "NATIVE_UINT_TYPE",
                 "POINTER_CAST",
-            ]:
+            ):
                 t = "sizeof(" + t + cl
             else:
                 if arg.get_modifier() == "pointer":
                     t = "sizeof(" + t + "*)"
                 else:
-                    t = t + "::SERIALIZED_SIZE"
-            arg_str += t
-            arg_str += " + "
+                    t += "::SERIALIZED_SIZE"
+            arg_str += f"{t} + "
         arg_str = arg_str.strip(" + ")
         return arg_str
 


### PR DESCRIPTION

| | |
|:---|:---|
|**_Originating Project/Creator_**| @OfficialAhmed |
|**_Affected Component_**| autocoder |
|**_Affected Architectures(s)_**| - |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|n  |
|**_Builds Without Errors (y/n)_**|y  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  n |

---
## Change Description

The PR aims for better performance by replacing **List** iteration to **Tuple** as tuples uses less memory and has fixed malloc hence increasing code execution [link](https://www.educative.io/answers/tuples-vs-list-in-python). This PR also minimizes old implementation of string formatting for code readably  



## Rationale

[*] Performance: iterating Tuples is faster and takes less memory than Lists
[*] Minimizing code: Used newest implementation of string formatting (f-string) for code readability and minimization

## Testing/Review Recommendations

None

## Future Work

When it comes to hard-coded iteration its recommended to use Tuples for better performance rather than Lists. And f-string formatting is easier to read than the method string.format() 